### PR TITLE
Improve Graph debug print feature

### DIFF
--- a/cupy/cuda/graph.pxd
+++ b/cupy/cuda/graph.pxd
@@ -13,4 +13,4 @@ cdef class Graph:
 
     cpdef launch(self, stream=*)
     cpdef upload(self, stream=*)
-    cpdef str debug_dot_str(self, unsigned int)
+    cpdef debug_dot_str(self, flags=*)

--- a/cupy/cuda/graph.pyx
+++ b/cupy/cuda/graph.pyx
@@ -76,7 +76,7 @@ cdef class Graph:
             stream_ptr = stream.ptr
         runtime.graphUpload(self.graphExec, stream_ptr)
 
-    cpdef str debug_dot_str(self, unsigned int flags):
+    cpdef debug_dot_str(self, flags=0):
         """Make DOT formatted string of CUDA graph definition for debugging.
 
         Args:

--- a/cupy_backends/cuda/api/runtime.pyx
+++ b/cupy_backends/cuda/api/runtime.pyx
@@ -1115,11 +1115,14 @@ cpdef graphUpload(intptr_t graphExec, intptr_t stream):
     check_status(status)
 
 cpdef graphDebugDotPrint(intptr_t graph, str path, unsigned int flags):
+    if runtimeGetVersion() < 11030:
+        raise RuntimeError('graphDebugDotPrint requires CUDA 11.3+')
     path_byte = path.encode()
     cdef const char* c_path = path_byte
     with nogil:
         status = cudaGraphDebugDotPrint(<Graph>(graph), c_path, flags)
     check_status(status)
+
 
 ##############################################################################
 # Profiler

--- a/cupy_backends/cuda/cupy_cuda_runtime.h
+++ b/cupy_backends/cuda/cupy_cuda_runtime.h
@@ -84,6 +84,15 @@ cudaError_t cudaMemPoolGetAttribute(...) {
 
 #endif
 
+#if CUDA_VERSION < 11030
+// APIs added in CUDA 11.3
+
+cudaError_t cudaGraphDebugDotPrint(...) {
+    return cudaErrorUnknown;
+}
+
+#endif
+
 } // extern "C"
 
 #endif // #ifndef INCLUDE_GUARD_CUDA_CUPY_CUDA_RUNTIME_H


### PR DESCRIPTION
* Let's assign a default value of `flags=0`. Passing `0` to indicate no flags set makes sense for C users, but Python users might feel it like a magic number.
* CI was failing because it's new in CUDA 11.3. (CuPy supports CUDA 11.2 or later)
* Added a test.